### PR TITLE
Wrap sections with container and adjust spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,60 +18,70 @@
     </header>
 
     <section class="banner">
-        <h2 class="banner__titulo">Bem-vindo ao EJC Menino Jesus de Praga</h2>
-        <p class="banner__texto">Fique à vontade para ouvir nossa playlist e conhecer nossas redes.</p>
-        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/5BltlDGKokhZbdjathPJPe?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+        <div class="container">
+            <h2 class="banner__titulo">Bem-vindo ao EJC Menino Jesus de Praga</h2>
+            <p class="banner__texto">Fique à vontade para ouvir nossa playlist e conhecer nossas redes.</p>
+            <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/5BltlDGKokhZbdjathPJPe?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+        </div>
     </section>
 
     <section class="galeria">
-        <h2 class="galeria__titulo">Galeria</h2>
-        <div class="swiper">
-            <div class="swiper-wrapper">
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=800&q=60" alt="Cruz ao pôr do sol"/></div>
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1487958449943-2429e8be8625?auto=format&fit=crop&w=800&q=60" alt="Terço católico"/></div>
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1545951428-330029bc69c3?auto=format&fit=crop&w=800&q=60" alt="Estátua de Nossa Senhora"/></div>
+        <div class="container">
+            <h2 class="galeria__titulo">Galeria</h2>
+            <div class="swiper">
+                <div class="swiper-wrapper">
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=800&q=60" alt="Cruz ao pôr do sol"/></div>
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1487958449943-2429e8be8625?auto=format&fit=crop&w=800&q=60" alt="Terço católico"/></div>
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1545951428-330029bc69c3?auto=format&fit=crop&w=800&q=60" alt="Estátua de Nossa Senhora"/></div>
+                </div>
+                <div class="swiper-pagination"></div>
+                <div class="swiper-button-prev"></div>
+                <div class="swiper-button-next"></div>
             </div>
-            <div class="swiper-pagination"></div>
-            <div class="swiper-button-prev"></div>
-            <div class="swiper-button-next"></div>
         </div>
     </section>
 
     <section class="depoimentos">
-        <h2 class="depoimentos__titulo">Depoimentos</h2>
-        <div class="depoimentos__container">
-            <article class="depoimento">
-                <p class="depoimento__texto">"Participar do EJC transformou minha fé e minha vida."</p>
-                <p class="depoimento__autor">Maria Silva</p>
-            </article>
-            <article class="depoimento">
-                <p class="depoimento__texto">"Encontrei uma nova família na igreja e em Cristo."</p>
-                <p class="depoimento__autor">João Pereira</p>
-            </article>
-            <article class="depoimento">
-                <p class="depoimento__texto">"Uma experiência inesquecível de amor e serviço."</p>
-                <p class="depoimento__autor">Ana Souza</p>
-            </article>
+        <div class="container">
+            <h2 class="depoimentos__titulo">Depoimentos</h2>
+            <div class="depoimentos__container">
+                <article class="depoimento">
+                    <p class="depoimento__texto">"Participar do EJC transformou minha fé e minha vida."</p>
+                    <p class="depoimento__autor">Maria Silva</p>
+                </article>
+                <article class="depoimento">
+                    <p class="depoimento__texto">"Encontrei uma nova família na igreja e em Cristo."</p>
+                    <p class="depoimento__autor">João Pereira</p>
+                </article>
+                <article class="depoimento">
+                    <p class="depoimento__texto">"Uma experiência inesquecível de amor e serviço."</p>
+                    <p class="depoimento__autor">Ana Souza</p>
+                </article>
+            </div>
         </div>
     </section>
 
     <section class="topicos">
-        <h2 class="topicos__titulo">Acesse também</h2>
-        <ul class="topicos__lista">
-            <li class="topicos__item">
-                <a href="https://www.instagram.com/ejcmeninojesuspb/" class="topicos__links">Instagram</a>
-            </li>
-            <li class="topicos__item">
-                <a href="https://open.spotify.com/playlist/5BltlDGKokhZbdjathPJPe?si=bda19751c6fd4212" class="topicos__links">Spotify</a>
-            </li>
-            <li class="topicos__item">
-                <a href="https://goo.gl/maps/EFBdiAFH9i6kRrWH6" class="topicos__links">Localização</a>
-            </li>
-        </ul>
+        <div class="container">
+            <h2 class="topicos__titulo">Acesse também</h2>
+            <ul class="topicos__lista">
+                <li class="topicos__item">
+                    <a href="https://www.instagram.com/ejcmeninojesuspb/" class="topicos__links">Instagram</a>
+                </li>
+                <li class="topicos__item">
+                    <a href="https://open.spotify.com/playlist/5BltlDGKokhZbdjathPJPe?si=bda19751c6fd4212" class="topicos__links">Spotify</a>
+                </li>
+                <li class="topicos__item">
+                    <a href="https://goo.gl/maps/EFBdiAFH9i6kRrWH6" class="topicos__links">Localização</a>
+                </li>
+            </ul>
+        </div>
     </section>
 
     <footer class="rodape">
-        <p class="rodape__texto">&copy; 2024 EJC Menino Jesus de Praga</p>
+        <div class="container">
+            <p class="rodape__texto">&copy; 2024 EJC Menino Jesus de Praga</p>
+        </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.js"></script>
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -57,7 +57,7 @@ body{
     background: linear-gradient(97.54deg, rgba(0,47,82,0.85) 35.49%, rgba(50,101,137,0.85) 165.37%);
     color: var(--branco);
     text-align: center;
-    padding: 2rem 1rem;
+    padding: 2rem 0;
 }
 
 .banner__titulo {
@@ -72,7 +72,7 @@ body{
 
 .topicos {
     background-color: rgba(255,255,255,0.8);
-    padding: 2rem 1rem;
+    padding: 2rem 0;
 }
 
 .topicos__titulo {
@@ -107,7 +107,7 @@ body{
 
 .galeria {
     background-color: rgba(255,255,255,0.8);
-    padding: 2rem 1rem;
+    padding: 2rem 0;
 }
 
 .galeria__titulo {
@@ -129,7 +129,7 @@ body{
 
 .depoimentos {
     background-color: rgba(255,255,255,0.8);
-    padding: 2rem 1rem;
+    padding: 2rem 0;
     color: var(--azul);
 }
 
@@ -170,7 +170,7 @@ body{
 
 .rodape {
     text-align: center;
-    padding: 1rem;
+    padding: 1rem 0;
     background-color: transparent;
     color: var(--azul);
 }


### PR DESCRIPTION
## Summary
- wrap banner, gallery, testimonials, topics, and footer sections with a reusable `.container`
- adjust section paddings to rely on `.container` for horizontal spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc811ab7f0832bbc2ee733696c96b2