### PR TITLE
feat: add responsive header navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,15 @@
 <body>
     <canvas id="starfield"></canvas>
     <header class="cabecalho">
-        <div class="container">
+        <nav class="header__nav container">
             <h1 class="cabecalho__titulo"><span class="cabecalho__titulo--negrito">EJC</span> Menino Jesus de Praga</h1>
-        </div>
+            <button class="header__toggle" aria-label="Abrir menu">&#9776;</button>
+            <ul class="header__menu">
+                <li class="header__item"><a href="#galeria" class="header__link">Galeria</a></li>
+                <li class="header__item"><a href="#depoimentos" class="header__link">Depoimentos</a></li>
+                <li class="header__item"><a href="#topicos" class="header__link">Links</a></li>
+            </ul>
+        </nav>
     </header>
 
     <section class="banner">
@@ -23,7 +29,7 @@
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/playlist/5BltlDGKokhZbdjathPJPe?utm_source=generator&theme=0" width="100%" height="152" frameborder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
     </section>
 
-    <section class="galeria">
+    <section id="galeria" class="galeria">
         <h2 class="galeria__titulo">Galeria</h2>
         <div class="swiper">
             <div class="swiper-wrapper">
@@ -37,7 +43,7 @@
         </div>
     </section>
 
-    <section class="depoimentos">
+    <section id="depoimentos" class="depoimentos">
         <h2 class="depoimentos__titulo">Depoimentos</h2>
         <div class="depoimentos__container">
             <article class="depoimento">
@@ -55,7 +61,7 @@
         </div>
     </section>
 
-    <section class="topicos">
+    <section id="topicos" class="topicos">
         <h2 class="topicos__titulo">Acesse também</h2>
         <ul class="topicos__lista">
             <li class="topicos__item">

--- a/script.js
+++ b/script.js
@@ -55,3 +55,10 @@ const swiper = new Swiper('.swiper', {
     prevEl: '.swiper-button-prev'
   }
 });
+
+const headerToggle = document.querySelector('.header__toggle');
+const headerMenu = document.querySelector('.header__menu');
+
+headerToggle.addEventListener('click', () => {
+  headerMenu.classList.toggle('header__menu--ativo');
+});

--- a/style.css
+++ b/style.css
@@ -41,7 +41,58 @@ body{
     background: rgba(0, 47, 82, 0.85);
     color: var(--branco);
     padding: 1rem 0;
-    text-align: center;
+}
+
+.header__nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+}
+
+.header__menu {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+}
+
+.header__link {
+    text-decoration: none;
+    color: var(--branco);
+}
+
+.header__toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--branco);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.header__menu--ativo {
+    display: flex;
+}
+
+@media (max-width: 768px) {
+    .header__nav {
+        flex-wrap: wrap;
+    }
+
+    .header__menu {
+        display: none;
+        flex-direction: column;
+        width: 100%;
+        margin-top: 1rem;
+    }
+
+    .header__toggle {
+        display: block;
+    }
+
+    .header__menu--ativo {
+        display: flex;
+    }
 }
 
 .cabecalho__titulo--negrito {


### PR DESCRIPTION
## Summary
- wrap header content in nav and add responsive menu with toggle
- style header with flex layout and mobile hamburger
- add JS to toggle menu visibility

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc81791200832bace9e5f2c90e7931