### PR TITLE
refactor: apply grid layout to sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,15 +25,17 @@
 
     <section class="galeria">
         <h2 class="galeria__titulo">Galeria</h2>
-        <div class="swiper">
-            <div class="swiper-wrapper">
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=800&q=60" alt="Cruz ao pôr do sol"/></div>
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1487958449943-2429e8be8625?auto=format&fit=crop&w=800&q=60" alt="Terço católico"/></div>
-                <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1545951428-330029bc69c3?auto=format&fit=crop&w=800&q=60" alt="Estátua de Nossa Senhora"/></div>
+        <div class="galeria__container">
+            <div class="swiper">
+                <div class="swiper-wrapper">
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1508780709619-79562169bc64?auto=format&fit=crop&w=800&q=60" alt="Cruz ao pôr do sol"/></div>
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1487958449943-2429e8be8625?auto=format&fit=crop&w=800&q=60" alt="Terço católico"/></div>
+                    <div class="swiper-slide"><img src="https://images.unsplash.com/photo-1545951428-330029bc69c3?auto=format&fit=crop&w=800&q=60" alt="Estátua de Nossa Senhora"/></div>
+                </div>
+                <div class="swiper-pagination"></div>
+                <div class="swiper-button-prev"></div>
+                <div class="swiper-button-next"></div>
             </div>
-            <div class="swiper-pagination"></div>
-            <div class="swiper-button-prev"></div>
-            <div class="swiper-button-next"></div>
         </div>
     </section>
 
@@ -57,17 +59,11 @@
 
     <section class="topicos">
         <h2 class="topicos__titulo">Acesse também</h2>
-        <ul class="topicos__lista">
-            <li class="topicos__item">
-                <a href="https://www.instagram.com/ejcmeninojesuspb/" class="topicos__links">Instagram</a>
-            </li>
-            <li class="topicos__item">
-                <a href="https://open.spotify.com/playlist/5BltlDGKokhZbdjathPJPe?si=bda19751c6fd4212" class="topicos__links">Spotify</a>
-            </li>
-            <li class="topicos__item">
-                <a href="https://goo.gl/maps/EFBdiAFH9i6kRrWH6" class="topicos__links">Localização</a>
-            </li>
-        </ul>
+        <div class="topicos__container">
+            <a href="https://www.instagram.com/ejcmeninojesuspb/" class="topicos__links">Instagram</a>
+            <a href="https://open.spotify.com/playlist/5BltlDGKokhZbdjathPJPe?si=bda19751c6fd4212" class="topicos__links">Spotify</a>
+            <a href="https://goo.gl/maps/EFBdiAFH9i6kRrWH6" class="topicos__links">Localização</a>
+        </div>
     </section>
 
     <footer class="rodape">

--- a/style.css
+++ b/style.css
@@ -82,13 +82,11 @@ body{
     margin-bottom: 1rem;
 }
 
-.topicos__lista {
-    list-style: none;
-    display: flex;
-    justify-content: center;
+.topicos__container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1rem;
-    flex-wrap: wrap;
-    padding: 0;
+    justify-items: center;
 }
 
 .topicos__links {
@@ -98,6 +96,9 @@ body{
     padding: 0.5rem 1rem;
     border-radius: 8px;
     font-weight: 700;
+    display: block;
+    text-align: center;
+    width: 100%;
 }
 
 .topicos__links:hover {
@@ -122,6 +123,13 @@ body{
     max-width: 600px;
 }
 
+.galeria__container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    justify-items: center;
+}
+
 .swiper-slide img {
     width: 100%;
     border-radius: 8px;
@@ -142,10 +150,10 @@ body{
 }
 
 .depoimentos__container {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 1rem;
-    max-width: 600px;
+    max-width: 1200px;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- wrap galeria and topicos content in dedicated containers
- refactor section containers to use responsive CSS grid
- center topic links and gallery content with consistent gaps

## Testing
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc817d9274832bbc129cd6f06b8b87